### PR TITLE
Overwrite color definitions in rendermime package

### DIFF
--- a/style/index.css
+++ b/style/index.css
@@ -5,6 +5,7 @@
 
 @import './variables.css';
 @import './urls.css';
+@import './packages/@jupyterlab/rendermime/custom.css';
 
 /* Set the default typography for monospace elements */
 tt,

--- a/style/packages/@jupyterlab/rendermime/custom.css
+++ b/style/packages/@jupyterlab/rendermime/custom.css
@@ -1,0 +1,9 @@
+.jp-RenderedText pre .ansi-red-fg {
+  color: var(--cl-red);
+}
+.jp-RenderedText pre .ansi-blue-fg {
+  color: var(--cl-color2medium);
+}
+.jp-RenderedText pre .ansi-green-fg {
+  color: var(--cl-green);
+}


### PR DESCRIPTION
Some packages (e.g., `@jupyterlab/rendermime`) do not use CSS color variables defined as public API in JupyterLab themes. This PR is a monkey-patch for such packages.
