### PR TITLE
Provide a one-stop development installation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,8 +24,14 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
     - run: npm ci
-    - run: npm run build --if-present
-    - run: npm run build:webpack --if-present
+    - name: Test the theme
+      run: |
+        .venv/bin/jupyter labextension list 2>&1 | grep -ie "jupyterlab_city-lights-theme.*OK"
+        npm test
       env:
         CI: true

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "bump": "standard-version",
     "bump:dryrun": "standard-version --dry-run",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
+    "postci": "python3 -m venv .venv && .venv/bin/pip install jupyterlab==3",
     "postpublish": "git push --follow-tags origin master",
     "prepublishOnly": "npm run clean && npm run build",
     "watch": "tsc -w"

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "postci": "python3 -m venv .venv && .venv/bin/pip install jupyterlab==3",
     "postpublish": "git push --follow-tags origin master",
     "prepublishOnly": "npm run clean && npm run build",
+    "test": ".venv/bin/python -m jupyterlab.browser_check",
     "watch": "tsc -w"
   },
   "dependencies": {


### PR DESCRIPTION
This PR aims to simplify the process for development installation and to avoid messing up system-wide Python environment of contributors. To be specific, we will be able to set up the development environment by just running `npm ci`.